### PR TITLE
chore: release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/jpwesselink/chromakopia/compare/v0.1.0-pr-4.82371ad...v0.1.0) - 2026-03-16
+
+### Other
+
+- Add fade_to_foreground/gradient/background on Animation
+- Layered animation system with easing, rename to chromakopia
+- Initial commit


### PR DESCRIPTION



## 🤖 New release

* `chromakopia`: 0.1.0-pr-4.82371ad -> 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.0](https://github.com/jpwesselink/chromakopia/compare/v0.1.0-pr-4.82371ad...v0.1.0) - 2026-03-16

### Other

- Add fade_to_foreground/gradient/background on Animation
- Layered animation system with easing, rename to chromakopia
- Initial commit
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).