### PR TITLE
Fix animation cleanup: trailing newline + don't abort task

### DIFF
--- a/src/animate/mod.rs
+++ b/src/animate/mod.rs
@@ -62,9 +62,8 @@ impl Animation {
 impl Drop for Animation {
     fn drop(&mut self) {
         self.running.store(false, Ordering::SeqCst);
-        if let Some(h) = self.handle.take() {
-            h.abort();
-        }
+        // Don't abort — let the task finish its cleanup (cursor restore, line clear).
+        // The task will see running=false on the next loop check and exit cleanly.
     }
 }
 
@@ -137,7 +136,7 @@ where
             if lines_printed > 0 {
                 buf.push_str(&format!("\x1B[{}F", lines_printed));
             }
-            buf.push_str("\x1B[?25h"); // show cursor
+            buf.push_str("\x1B[?25h\n"); // show cursor, newline so next output starts clean
             let mut stderr = std::io::stderr().lock();
             let _ = write!(stderr, "{}", buf);
             let _ = stderr.flush();


### PR DESCRIPTION
## Summary

- **Stop aborting the task in `drop()`** — `h.abort()` killed the spawned task before its cleanup code (cursor restore, line clear) could run. Now the task detaches and finishes naturally since `running` is already set to false.
- **Print a trailing newline after cleanup** — the animation clear sequence left the cursor on the same line, so subsequent output ran into it.

## Test plan

- [ ] Run any standalone animation (`rainbow`, `glow`, `flap`, etc.), stop it, and verify the next output starts on its own line
- [ ] Verify cursor is visible after animation stops
- [ ] `cargo test` passes